### PR TITLE
Tolerate release package file duplicates

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,3 +94,4 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: artifact
+          skip_existing: true


### PR DESCRIPTION
At least temporarily, in an attempt to fix missing Python 3.11 wheels.

Fixes #10.